### PR TITLE
Decrease the log level of a ws-ping event being sent

### DIFF
--- a/src/taoensso/sente.cljc
+++ b/src/taoensso/sente.cljc
@@ -1605,7 +1605,7 @@
                   (when-let [;; No conn send/recv activity w/in kalive window?
                              no-activity? (= udt-t0 udt-t1)]
 
-                    (timbre/debugf "Client will send ws-ping to server: %s"
+                    (timbre/tracef "Client will send ws-ping to server: %s"
                       {:ms-since-last-activity (- (enc/now-udt) udt-t1)
                        :timeout-ms ws-ping-timeout-ms})
 


### PR DESCRIPTION
ws-ping events are very frequent and with thousands of connections they tend to overwhelm the logs, bringing little value, even when debugging. They are more suited for the :trace log level, as the other :debug level messages from sente are quite helpful and not overly verbose.