### PR TITLE
Update timbre version, as the old one was giving deprecation warnings

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
    [com.taoensso/encore      "3.62.1"]
    [org.java-websocket/Java-WebSocket "1.5.3"]
    [org.clojure/tools.reader "1.3.6"]
-   [com.taoensso/timbre      "6.2.2"]]
+   [com.taoensso/timbre      "6.5.0"]]
 
   :test-paths ["test" #_"src"]
 


### PR DESCRIPTION
Hi, using sente functions with current version shows cljs warnings.
E.g. using sente/start-client-chsk-router!
```
7 Warnings
Warning :fn-deprecated in [taoensso/timbre.cljc](http://localhost:9630/build/null) at 68:41
taoensso.encore/compile-str-filter is deprecated
  65 | ;; fn or `ns-pattern`) and `ns-pattern` (subtype of `ns-filter`).
  66 | 
  67 | (let [fn?         fn?
  68 |       compile     (enc/fmemoize (fn [x] (enc/compile-str-filter x)))
  69 |       conform?*   (enc/fmemoize (fn [x ns] ((compile x) ns)))
  70 |       ;; conform? (enc/fmemoize (fn [x ns] (if (fn? x) (x ns) ((compile x) ns))))
  71 |       conform?
  72 |       (fn [ns-filter ns]
Warning :fn-deprecated in [taoensso/timbre.cljc](http://localhost:9630/build/null) at 300:83
taoensso.encore/limiter is deprecated
 297 | (comment ((fn foo [x y] (get-env)) 5 10))
 298 | 
 299 | #?(:clj (defonce ^:private get-agent        (enc/fmemoize (fn [appender-id      ] (agent nil :error-mode :continue)))))
 300 | (do     (defonce ^:private get-rate-limiter (enc/fmemoize (fn [appender-id specs] (enc/limiter specs)))))
 301 | 
 302 | (comment
 303 |   (get-agent :my-appender)
 304 |   (def rf (get-rate-limiter :my-appender [[10 5000]])))
Warning :fn-deprecated in [taoensso/timbre.cljc](http://localhost:9630/build/null) at 316:12
taoensso.encore/kw-identical? is deprecated
 313 | 
 314 |      :cljs
 315 |      (let [{:keys [pattern]} timestamp-opts]
 316 |        (if (enc/kw-identical? pattern :iso8601)
 317 |          (.toISOString (js/Date. instant)) ; e.g. 2020-09-14T08:29:49.711Z (UTC)
 318 |          ;; Pattern can also be be `goog.i18n.DateTimeFormat.Format`, etc.
 319 |          (.format
 320 |            (goog.i18n.DateTimeFormat. pattern)
Warning :fn-deprecated in [taoensso/timbre.cljc](http://localhost:9630/build/null) at 572:21
taoensso.encore/kw-identical? is deprecated
 569 | (defn- parse-vargs
 570 |   "vargs -> [?err ?meta ?msg-fmt api-vargs]"
 571 |   [?err msg-type vargs]
 572 |   (let [auto-error? (enc/kw-identical? ?err :auto)
 573 |         fmt-msg?    (enc/kw-identical? msg-type :f)
 574 |         [v0] vargs]
 575 | 
 576 |     (if (and auto-error? (enc/error? v0))
Warning :fn-deprecated in [taoensso/timbre.cljc](http://localhost:9630/build/null) at 573:21
taoensso.encore/kw-identical? is deprecated
 570 |   "vargs -> [?err ?meta ?msg-fmt api-vargs]"
 571 |   [?err msg-type vargs]
 572 |   (let [auto-error? (enc/kw-identical? ?err :auto)
 573 |         fmt-msg?    (enc/kw-identical? msg-type :f)
 574 |         [v0] vargs]
 575 | 
 576 |     (if (and auto-error? (enc/error? v0))
 577 |       (let [?err     v0
Warning :fn-deprecated in [taoensso/timbre.cljc](http://localhost:9630/build/null) at 700:26
taoensso.encore/kw-identical? is deprecated
 697 |                  (fn [?appender-opts] ; Return timestamp_ delay
 698 |                    (if (or
 699 |                          (nil? ?appender-opts)
 700 |                          (enc/kw-identical? ?appender-opts :inherit) ; Back compatibility
 701 |                          )
 702 | 
 703 |                      (get-shared-delay       @base-opts_)
 704 |                      (get-shared-delay (conj @base-opts_ ?appender-opts)))))
Warning :fn-deprecated in [taoensso/timbre.cljc](http://localhost:9630/build/null) at 712:28
taoensso.encore/kw-identical? is deprecated
 709 |                    (protected-fn "Timbre error when calling (output-fn <data>)"
 710 |                      (if (or
 711 |                            (nil? ?appender-fn)
 712 |                            (enc/kw-identical? ?appender-fn :inherit) ; Back compatibility
 713 |                            )
 714 | 
 715 |                        base-fn
 716 |                        ?appender-fn))))
```

Which was fixed in timbre 6.4.0. https://github.com/taoensso/timbre/issues/379#issuecomment-1959881073

I've updated it to the newest one, tested it in my repo and it works well.