### PR TITLE
Optional: Add basic deps.edn file for a project

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,7 @@
+{:paths ["src" "resources"],
+ :deps
+ {org.clojure/core.async {:mvn/version "1.6.673"},
+  com.taoensso/encore {:mvn/version "3.62.1"},
+  org.java-websocket/Java-WebSocket {:mvn/version "1.5.3"},
+  org.clojure/tools.reader {:mvn/version "1.3.6"},
+  com.taoensso/timbre {:mvn/version "6.5.0"}}}


### PR DESCRIPTION
While adding #450, I needed `deps.edn` file, since my project is not using leiningen. 

This update contains only the basic version of the file that is needed to use it, without covering all the options from the project.cli. 

But it is useful because, without this, I could not require a fork of this project to my repo, which I was using to test if my suggestion worked (e.g. using `:git/url` or `:local/root` in deps.edn). So it is helpful to have it for that use case. 

On the other hand, I understand if you may not want to have this to additionally keep the versions up-to-date in another file.
