### PR TITLE
Do not add a beforeunload event listener when running inside NodeJS

### DIFF
--- a/src/taoensso/sente.cljc
+++ b/src/taoensso/sente.cljc
@@ -1350,8 +1350,9 @@
 
 (def client-unloading?_ (atom false))
 #?(:cljs
-   (.addEventListener goog/global "beforeunload"
-     (fn [event] (reset! client-unloading?_ true) nil)))
+   (when-not node-target?
+     (.addEventListener goog/global "beforeunload"
+       (fn [event] (reset! client-unloading?_ true) nil))))
 
 (defn- retry-connect-chsk!
   [chsk backoff-ms-fn connect-fn retry-count]


### PR DESCRIPTION
This solves this problem:
```
SHADOW import error /home/asp/projects/xxx/.shadow-cljs/builds/server/dev/out/cljs-runtime/taoensso.sente.js

/home/asp/projects/xxx/target/private/js/server.js:64
  /* ignore this, look at stacktrace */ fn.call(global, require, module, __filename, __dirname);
                                           ^
TypeError: goog.global.addEventListener is not a function
    at /home/asp/projects/xxx/.shadow-cljs/builds/server/dev/out/cljs-runtime/taoensso/sente.cljc:1353:4
    at global.SHADOW_IMPORT (/home/asp/projects/xxx/target/private/js/server.js:64:44)
    at /home/asp/projects/xxx/target/private/js/server.js:1624:1
    at Object.<anonymous> (/home/asp/projects/xxx/target/private/js/server.js:1638:3)
    at Module._compile (node:internal/modules/cjs/loader:1233:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1287:10)
    at Module.load (node:internal/modules/cjs/loader:1091:32)
    at Function.Module._load (node:internal/modules/cjs/loader:938:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:83:12)
    at node:internal/main/run_main_module:23:47
```