### PR TITLE
Fix option to use custom WebSocket constructor

### DIFF
--- a/src/taoensso/sente.cljc
+++ b/src/taoensso/sente.cljc
@@ -2003,7 +2003,7 @@
             :packer    packer
             :ws-kalive-ms       ws-kalive-ms
             :ws-ping-timeout-ms ws-ping-timeout-ms
-            :ws-constructor     default-client-ws-constructor}
+            :ws-constructor     ws-constructor}
 
            ws-chsk-opts
            (merge common-chsk-opts


### PR DESCRIPTION
Commit f560294 introduced the option to use a custom Websocket constructor. But even if the caller of `make-channel-socket-client!` passed in the optional `:ws-constructor` key, the value of that key was never used. The code from that commit always used the `default-client-ws-constructor` function.

Which probably means nobody has ever used that option until now :-)

[Re: #325]